### PR TITLE
Ignore major version updates for govuk-frontend

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
   open-pull-requests-limit: 10
   allow:
   - dependency-type: production
+  ignore:
+  - dependency-name: govuk-frontend
+    update-types: ["version-update:semver-major"]
+  - dependency-name: digitalmarketplace-govuk-frontend
+    update-types: ["version-update:semver-major"]
 - package-ecosystem: "npm"
   directory: "/"
   schedule:


### PR DESCRIPTION
Supplier frontend is not fully on the Design System. So we need to carry on using the previous major version (https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend#using-govuk-frontend-v2).

Fixes the problem of https://github.com/Crown-Commercial-Service/digitalmarketplace-supplier-frontend/pull/1486