### PR TITLE
Update digitalmarketplace-govuk-frontend to version 3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2806,9 +2806,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-2.9.2.tgz",
-      "integrity": "sha512-c3I82UTBJhAlhzmtaEH+9WxxGuIVyQq1II7xgZjsq1ttEGMKa0AyShxV+bXue6K31tvx4rkOyGmWC0WlUllC/g=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-3.1.0.tgz",
+      "integrity": "sha512-OsE91RafMG+9VtgoA0BoqmoW1vKfgRf0LFzMuP6+z8rIccM81HCogBe9uPqH5dBWhLgfc+CPQ34FvuMRBUX8rg=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4403,9 +4403,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.13.0.tgz",
-      "integrity": "sha512-6XDtTt5plSrPQvPgLFN4LCtb9ULuqoXCgkHy5c7XE/70/sVm47RPbLR11tYGPcmV8cOApBhW0wL8y8ryspHfpw=="
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
+      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA=="
     },
     "govuk_frontend_toolkit": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "del": "^6.0.0",
     "digitalmarketplace-frameworks": "^18.4.1",
     "digitalmarketplace-frontend-toolkit": "^36.1.2",
-    "digitalmarketplace-govuk-frontend": "^2.9.2",
+    "digitalmarketplace-govuk-frontend": "^3.1.0",
     "govuk-country-and-territory-autocomplete": "1.0.1",
     "govuk-elements-sass": "3.1.3",
     "govuk-frontend": "2.13.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "digitalmarketplace-govuk-frontend": "^3.1.0",
     "govuk-country-and-territory-autocomplete": "1.0.1",
     "govuk-elements-sass": "3.1.3",
-    "govuk-frontend": "2.13.0",
+    "govuk-frontend": "^3.14.0",
     "govuk_frontend_toolkit": "5.2.0",
     "gulp": "^4.0.2",
     "gulp-filelog": "0.4.1",


### PR DESCRIPTION
We need to do this one manually because we tell dependabot to ignore it