### PR TITLE
Add the notification banner

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -15,6 +15,7 @@ from dmutils.email.dm_mailchimp import DMMailChimpClient
 from dmutils.flask import timed_render_template as render_template
 from dmutils.forms.helpers import get_errors_from_wtform, govuk_options
 from dmutils.errors import render_error_page
+from dmutils.dmp_so_status import are_new_frameworks_live
 
 from ...main import main, content_loader, direct_plus_client
 from ... import data_api_client
@@ -112,7 +113,8 @@ def dashboard():
             'standstill': get_frameworks_by_status(all_frameworks, 'standstill', 'made_application'),
             'live': get_frameworks_by_status(all_frameworks, 'live', 'onFramework'),
             'last_dos': get_most_recent_expired_dos_framework(all_frameworks),
-        }
+        },
+        are_new_frameworks_live=are_new_frameworks_live(request.args)
     ), 200
 
 

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -23,6 +23,7 @@
 {% from "digitalmarketplace/components/attachment/macro.njk" import dmAttachment %}
 {% from "digitalmarketplace/components/footer/macro.njk" import dmFooter %}
 {% from "digitalmarketplace/components/banner/macro.njk" import dmBanner %}
+{% from "digitalmarketplace/components/new-framework-banner/macro.njk" import dmNewFrameworkBanner %}
 
 {% set assetPath = '/suppliers/static' %}
 

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -19,6 +19,14 @@
 
 {% block mainContent %}
 
+  {% if are_new_frameworks_live %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        {{ dmNewFrameworkBanner() }}
+      </div>
+    </div>
+  {% endif %}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <span class="govuk-caption-xl">{{ current_user.email_address }}</span>


### PR DESCRIPTION
- Add the banner with the logic
- Add tests for the banner

This is from the ticket [OST-134](https://crowncommercialservice.atlassian.net/browse/OST-134) (6/5)

This is a screenshot of what the login page would look like:
![localhost_suppliers_show_dmp_so_banner=true](https://user-images.githubusercontent.com/58297459/148527637-44fc1755-2019-4d06-a2db-9dc99aa0d873.png)

The logic used is the same as in https://github.com/Crown-Commercial-Service/digitalmarketplace-user-frontend/pull/422
